### PR TITLE
GEÇİCİ: 3.10 segfault kanıt deneyi (birleştirilmeyecek)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,99 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: python -m pytest tests/ -q
 
+
+  # ---------------------------------------------------------------------
+  # GEÇİCİ — Python 3.10 segfault'unun sebebini kanıtlamak için.
+  # Kanıt alındıktan sonra bu job SİLİNECEK (PR birleştirilmeyecek).
+  #
+  # Soru: segfault'u bu turda eklenen tests/test_project_search.py mı
+  # tetikliyor (sıra/zamanlama), yoksa dulwich'in cp310 tekerleği mi?
+  #
+  # Tasarım: AYNI ortamda tam suite 10'ar kez, A) testler dahil,
+  # B) testler hariç. Taban oran ~%40 (5 koşunun 2'si), yani 10 turda
+  # nedensellik varsa A'da görünmemesi olasılığı 0.6^10 ≈ %0.6.
+  # Job HİÇBİR ZAMAN kırmızı yanmaz: amaç sayı toplamak, kapı olmak değil.
+  # ---------------------------------------------------------------------
+  segfault-kanit:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install system dependencies (PyQt6 headless)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libxcb-cursor0 libgl1 libegl1 libglib2.0-0 \
+            libdbus-1-3 libxkbcommon0 libfontconfig1
+
+      # Kırmızı koşulardaki ortamla AYNI olsun diye pandoc da kuruluyor:
+      # pandoc yoksa 12 test skip olur ve suite'in ZAMANLAMASI değişir.
+      - name: Install pandoc
+        env:
+          PANDOC_VERSION: "3.11"
+        run: |
+          set -e
+          URL="https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb"
+          curl -sfL --retry 5 --retry-all-errors --connect-timeout 15 -o /tmp/pandoc.deb "$URL"
+          sudo dpkg -i /tmp/pandoc.deb
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r desktop/requirements.txt pytest
+
+      - name: Sürümler
+        run: pip freeze | grep -iE "pyqt6|dulwich|pytest"
+
+      - name: A) tam suite x10 — test_project_search DAHİL
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          seg=0; dus=0
+          for i in $(seq 1 10); do
+            python -m pytest tests/ -q -p no:cacheprovider > /tmp/a$i.log 2>&1 || dus=$((dus+1))
+            if grep -q "Segmentation fault" /tmp/a$i.log; then
+              seg=$((seg+1))
+              echo "--- A tur $i: SEGFAULT ---"
+              grep -A 3 "Current thread" /tmp/a$i.log | head -5
+            fi
+          done
+          echo "SONUC_A segfault=$seg/10 dusen=$dus/10"
+
+      - name: B) tam suite x10 — test_project_search HARİÇ
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          seg=0; dus=0
+          for i in $(seq 1 10); do
+            python -m pytest tests/ -q -p no:cacheprovider \
+              --ignore=tests/test_project_search.py > /tmp/b$i.log 2>&1 || dus=$((dus+1))
+            if grep -q "Segmentation fault" /tmp/b$i.log; then
+              seg=$((seg+1))
+              echo "--- B tur $i: SEGFAULT ---"
+              grep -A 3 "Current thread" /tmp/b$i.log | head -5
+            fi
+          done
+          echo "SONUC_B segfault=$seg/10 dusen=$dus/10"
+
+      - name: C) yalnız test_version_ops x20 (tek başına da oluyor mu)
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          seg=0
+          for i in $(seq 1 20); do
+            python -m pytest tests/test_version_ops.py -q -p no:cacheprovider \
+              > /tmp/c$i.log 2>&1 || true
+            if grep -q "Segmentation fault" /tmp/c$i.log; then seg=$((seg+1)); fi
+          done
+          echo "SONUC_C segfault=$seg/20"
+
   test-windows:
     # Windows uygulamanın BİRİNCİL hedefi — release bir Windows exe'si üretiyor
     # — ama test paketi 2026-08-31'e kadar Windows'ta HİÇ koşmadı: ci.yml


### PR DESCRIPTION
Python 3.10'da tekrarlanan segfault'un sebebini kanıtlamak için tek koşuluk deney.

**Soru:** segfault'u bu turda eklenen `tests/test_project_search.py` mı tetikliyor, yoksa dulwich'in cp310 tekerleği mi?

**Tasarım:** aynı 3.10 ortamında tam suite 10'ar kez —
- A) `test_project_search` DAHİL
- B) HARİÇ (`--ignore`)
- C) yalnız `test_version_ops` x20

Taban oran ~%40 (son 5 koşunun 2'si). 10 turda nedensellik varsa A'da hiç görünmemesi olasılığı 0.6^10 ≈ %0.6.

**Bu PR BİRLEŞTİRİLMEYECEK** — sonuç alınınca kapatılacak, job silinecek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)