### PR TITLE
GEÇİCİ: 3.10 segfault — gdb yığın izi (birleştirilmeyecek)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,116 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: python -m pytest tests/ -q
 
+
+  # ---------------------------------------------------------------------
+  # GEÇİCİ — Python 3.10 segfault'unun C seviyesindeki yığın izini almak için.
+  # Kanıt alındıktan sonra bu job SİLİNECEK (PR birleştirilmeyecek).
+  #
+  # faulthandler yalnız PYTHON karesini veriyor; çökmenin hangi kütüphanede
+  # (dulwich'in Rust uzantısı? Qt? libc?) olduğunu göstermiyor. pytest
+  # doğrudan gdb ALTINDA koşuluyor: gdb SIGSEGV'de programı durdurur ve
+  # tam yığın alınır. Core dump'a gerek yok (runner'da core_pattern
+  # apport'a gidiyor olabilir).
+  #
+  # Oran ~%25 olduğu için 15 tura kadar deneniyor; ilk yakalamada duruluyor.
+  # ---------------------------------------------------------------------
+  segfault-gdb:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install system dependencies (PyQt6 headless) + gdb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libxcb-cursor0 libgl1 libegl1 libglib2.0-0 \
+            libdbus-1-3 libxkbcommon0 libfontconfig1 gdb
+          gdb --version | head -1
+
+      - name: Install pandoc
+        env:
+          PANDOC_VERSION: "3.11"
+        run: |
+          set -e
+          URL="https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb"
+          curl -sfL --retry 5 --retry-all-errors --connect-timeout 15 -o /tmp/pandoc.deb "$URL"
+          sudo dpkg -i /tmp/pandoc.deb
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r desktop/requirements.txt pytest
+
+      - name: Sürümler
+        run: pip freeze | grep -iE "pyqt6|dulwich|pytest"
+
+      # dulwich'in C/Rust uzantısı var mı — yığını okurken lazım olacak
+      - name: dulwich uzantıları
+        run: |
+          python - <<'PY'
+          import dulwich, os, glob
+          d = os.path.dirname(dulwich.__file__)
+          print("dulwich dizini:", d)
+          for p in sorted(glob.glob(os.path.join(d, "*.so"))):
+              print("  ", os.path.basename(p))
+          try:
+              import dulwich._objects as o
+              print("dulwich._objects (C hızlandırma) YÜKLÜ:", o.__file__)
+          except ImportError as e:
+              print("dulwich._objects YOK:", e)
+          PY
+
+      - name: gdb altında tam suite — SIGSEGV yakalanana kadar (en çok 15 tur)
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          yakalandi=0
+          for i in $(seq 1 15); do
+            echo "::group::tur $i"
+            gdb -q -batch \
+                -ex "set pagination off" \
+                -ex "set confirm off" \
+                -ex "run" \
+                -ex "printf \"\\n===== FAULT: BU THREAD =====\\n\"" \
+                -ex "bt 40" \
+                -ex "printf \"\\n===== KAYITLAR =====\\n\"" \
+                -ex "info registers rip rsp" \
+                -ex "printf \"\\n===== TUM THREADLER =====\\n\"" \
+                -ex "thread apply all bt 25" \
+                -ex "printf \"\\n===== YUKLU KUTUPHANELER (fault adresi hangisinde) =====\\n\"" \
+                -ex "info sharedlibrary" \
+                --args python -m pytest tests/ -q -p no:cacheprovider \
+                > /tmp/g$i.log 2>&1 || true
+            if grep -q "SIGSEGV" /tmp/g$i.log; then
+              echo "::endgroup::"
+              echo "TUR $i: SIGSEGV YAKALANDI"
+              yakalandi=1
+              break
+            fi
+            echo "tur $i temiz"
+            echo "::endgroup::"
+          done
+          if [ "$yakalandi" = "0" ]; then
+            echo "15 turda SIGSEGV yakalanmadi (gdb altinda zamanlama degismis olabilir)"
+            exit 0
+          fi
+          echo "=============== YIGIN IZI ==============="
+          sed -n '/SIGSEGV/,$p' /tmp/g$i.log | head -200
+
+      - name: Yığın izlerini artefakt olarak yükle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gdb-loglari
+          path: /tmp/g*.log
+          if-no-files-found: ignore
+
   test-windows:
     # Windows uygulamanın BİRİNCİL hedefi — release bir Windows exe'si üretiyor
     # — ama test paketi 2026-08-31'e kadar Windows'ta HİÇ koşmadı: ci.yml


### PR DESCRIPTION
faulthandler yalnız Python karesini veriyor. pytest gdb altında koşuluyor; SIGSEGV yakalanınca C seviyesinde tam yığın alınacak.

Bir önceki deney (PR #1) sebebi daralttı: A) test_project_search dahil 3/10, B) hariç 2/10, C) yalnız test_version_ops 0/20. Yani arama özelliği sebep DEĞİL, ama tek başına test_version_ops da değil.

**Birleştirilmeyecek.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)