### PR TITLE
GECICI: Linux yayin yapisi on ucusu (birlestirilmeyecek)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,3 +236,79 @@ jobs:
         env:
           QT_QPA_PLATFORM: offscreen
         run: python -m pytest tests/test_derle_sh.py tests/test_synctex_live.py tests/test_tablo_derleme.py tests/test_ipucu_derleme.py tests/test_pdf_baglanti_derleme.py -v
+
+  # ============================================================
+  # GECICI ON UCUS ISI. BIRLESTIRILMEYECEK.
+  #
+  # `release.yml`in `build-linux` adimlari yalnizca `v*` tag push'unda
+  # kosuyor. Spec dosyalari v1.0.21'den SONRA degisti
+  # (desktop/latex-editor-linux.spec + scripts/paket_suzgeci.py), yani
+  # yayin yapisi bu haliyle CI'da hic kurulmadi. Bu is o adimlari birebir
+  # kopyaliyor; sonuc gorulunce PR birlestirilmeden kapatilacak ve dal
+  # silinecek.
+  # ============================================================
+  onucus-linux:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Gomulecek yorumlayici
+        run: python3 --version
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            python3-venv inkscape \
+            libxcb-cursor0 libgl1 libegl1 libglib2.0-0 \
+            libdbus-1-3 libxkbcommon0 libfontconfig1 \
+            libxkbcommon-x11-0 libxcb-icccm4 libxcb-keysyms1 libxcb-xkb1 \
+            libxcb-image0 libxcb-randr0 libxcb-render0 libxcb-render-util0 \
+            libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-util1 \
+            libxcb-xfixes0 libx11-xcb1
+
+      - name: Build AppImage
+        working-directory: desktop
+        run: bash build_appimage.sh
+
+      - name: AppImage bagimliliklari cozuluyor mu
+        working-directory: desktop
+        run: |
+          eklenti=$(find dist/latex-editor/_internal -name libqxcb.so | head -1)
+          test -n "$eklenti" || { echo "::error::libqxcb.so bulunamadi"; exit 1; }
+          eksik=$(LD_LIBRARY_PATH="$PWD/dist/latex-editor/_internal" \
+                  ldd "$eklenti" | grep "not found" || true)
+          if [ -n "$eksik" ]; then
+            echo "::error::AppImage kendi kendine yetmiyor, eksik kutuphaneler:"
+            echo "$eksik"
+            exit 1
+          fi
+          echo "xcb eklentisinin butun bagimliliklari cozuluyor"
+
+      - name: Yazim denetimi pakete girdi mi
+        working-directory: desktop
+        run: python3 ../scripts/paket_dogrula.py dist/latex-editor
+
+      # Yayin akisinda OLMAYAN ek olcum: suzgec gercekten calisti mi ve
+      # AppImage ne kadar buyuk. Windows tarafinda yerelde olculdu
+      # (99 katalog atildi, exe 88.06 MB); Linux sayisi bilinmiyordu.
+      - name: Paket icerigi ve boyut
+        working-directory: desktop
+        run: |
+          echo "--- Qt ceviri kataloglari (beklenen: yalniz en/tr) ---"
+          find dist/latex-editor/_internal -path "*Qt6/translations*" \
+            -name "qtbase_*.qm" -printf "%f\n" | sort
+          echo "--- bizim kataloglar ---"
+          find dist/latex-editor/_internal -name "latexeditor_*.qm" \
+            -printf "%f\n" | sort
+          echo "--- sozluk ---"
+          ls -la dist/latex-editor/_internal/sozlukler/ || true
+          echo "--- boyutlar ---"
+          du -sh dist/latex-editor
+          ls -la dist/*.AppImage 2>/dev/null || echo "AppImage dosyasi yok"


### PR DESCRIPTION
release.yml build-linux adimlari yalniz `v*` tag push unda kosuyor. Spec dosyalari v1.0.21 den SONRA degisti (desktop/latex-editor-linux.spec + scripts/paket_suzgeci.py), yani yayin yapisi bu haliyle CI da hic kurulmadi.

Bu PR o adimlari ci.yml e gecici bir is olarak kopyaliyor. Windows tarafi yerelde dogrulandi (99 katalog suzuldu, paket_dogrula gecti, exe 88.06 MB, paketlenmis uygulama qtbase_tr yukleyerek aciliyor). Eksik olan Linux yapisi.

SONUC GORULUNCE BIRLESTIRILMEDEN KAPATILACAK ve dal silinecek.